### PR TITLE
Update Memory-Addresses.txt for patch 2.51

### DIFF
--- a/Memory-Addresses.txt
+++ b/Memory-Addresses.txt
@@ -1,7 +1,7 @@
-WorkingDate = 1/21/2015 - Patch 2.5
+WorkingDate = 1/24/2015 - Patch 2.51
 
 
-InventoryAddress = 0x10BC070, 0x0
+InventoryAddress = 0x1115230, 0x0
 
 EquippedWeaponIDOffset = 0x1988
 


### PR DESCRIPTION
It took a little bit of trial and error, not being super familiar with Cheat Engine, but I followed your directions to come up with the proposed memory address change.

Below information for your own verification of my findings.

The offset above was located in memory address 0x02475230 on my machine (which translated to ffxiv.exe+1115230). That pointed to 11F56120, which pointed to 11F566A0, which is the start of the inventory area. At 0x1988 bytes into that area (at 11F58028), was my equipped weapon ID. A few bytes later, at 11F58030, is the 2-byte light value for my weapon.